### PR TITLE
ci(travis): remove greenkeeper lockfile upload step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,5 @@ node_js:
   - 8
   - 6
   - 4
-before_install:
-  - npm i -g npm@5
-  - npm i -g greenkeeper-lockfile@1
+before_install: npm i -g greenkeeper-lockfile@1
 before_script: greenkeeper-lockfile-update
-after_script: greenkeeper-lockfile-upload


### PR DESCRIPTION
There is a risk of leaking write key to make this work, without the write key it will fail.